### PR TITLE
Fix 64 Byte Password bug for structures that don't support .push (Fixes Issue #11)

### DIFF
--- a/scrypt.js
+++ b/scrypt.js
@@ -114,7 +114,13 @@
 
     function PBKDF2_HMAC_SHA256_OneIter(password, salt, dkLen) {
         // compress password if it's longer than hash block length
-        password = password.length <= 64 ? password : SHA256(password);
+        if(password.length > 64)
+        {
+          // coerces the structure into an array type if it lacks support for the .push operation 
+          // use [...password] when you instead of the "Array.prototype.slice.call" when you deprecate pre-ES6
+          // it's supposed to be faster in most browsers.
+          password = SHA256(password.push ? password : Array.prototype.slice.call(password, 0))
+        }
 
         var i;
         var innerLen = 64 + salt.length + 4;

--- a/test/test-vectors.json
+++ b/test/test-vectors.json
@@ -35,7 +35,6 @@
         "dkLen": 64,
         "derivedKey": "2101cb9b6a511aaeaddbbe09cf70f881ec568d574a2ffd4dabe5ee9820adaa478e56fd8f4ba5d09ffa1c6d927c40f4c337304049e8a952fbcbf45c6fa77a41a4"
     },
-
     {
         "password": "70617373776f7264",
         "salt": "7269636d6f6f",
@@ -44,6 +43,14 @@
         "r": "8",
         "dkLen": "32",
         "derivedKey": "e286ed0298808c0b4bb4272ce947091b0da06bb530c4cbab3923e44ff48bbc25"
+    },
+    {
+        "password": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "salt": "",
+        "N": 16,
+        "p": 1,
+        "r": 1,
+        "dkLen": 64,
+        "derivedKey": "563c6b92a82ab6e4d743241d02c787020b2376df98699893da03eebace365b358b2badb4f81a1cd3d01cc039338774bb6ebafbfa81108d7dea3dec721f12dfaf"
     }
-
 ]


### PR DESCRIPTION
This is a PR to fix #11

I've also submitted patches to scrypt-async-js