### PR TITLE
Replace CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm install scrypt-js
 **browser**
 
 ```html
-<script src="https://raw.githubusercontent.com/ricmoo/scrypt-js/master/scrypt.js" type="text/javascript"></script>
+<script src="https://cdn.jsdelivr.net/npm/scrypt-js/scrypt.js"></script>
 ```
 
 API


### PR DESCRIPTION
I replaced the Rawgit link with a [jsDelivr CDN link](https://www.jsdelivr.com/) in the readme. Unlike Rawgit, jsDelivr was built for this use case and also serves the correct content-type header.