### PR TITLE
fix: don't allow NaN/Infinity params

### DIFF
--- a/scrypt.js
+++ b/scrypt.js
@@ -251,7 +251,7 @@
     }
 
     function ensureInteger(value, name) {
-        if (typeof(value) !== "number" || (value % 1)) { throw new Error('invalid ' + name); }
+        if (!Number.isInteger(value)) { throw new Error('invalid ' + name); }
         return value;
     }
 

--- a/test/test-scrypt.js
+++ b/test/test-scrypt.js
@@ -6,6 +6,20 @@ const scrypt = require('../scrypt.js');
 
 const testVectors = require('./test-vectors.json');
 
+for (const invalid of [NaN, Infinity, -Infinity, 0.5, null]) {
+  for (let i = 0; i < 4; i++) {
+    const password = Buffer.from('password');
+    const salt = Buffer.from('salt');
+    const argname = ['N', 'r', 'p', 'dkLen'][i];
+    const args = [16, 1, 1, 64];
+    args[i] = invalid;
+    it(`Test ${invalid} rejection ${i}`, () => assert.rejects(
+      () => scrypt.scrypt(password, salt, ...args, () => {}),
+      { message: `invalid ${argname}` }
+    ));
+  }
+}
+
 for (let i = 0; i < testVectors.length; i++) {
     const test = testVectors[i];
 


### PR DESCRIPTION
I believe this is a regression in https://github.com/ricmoo/scrypt-js/commit/e55eb3983ae3f6dc9c56b6c88f4e2d788e7edab1#diff-714a4bf03391301f9f8a3a4b026cd1a82fa422b664209252422963d9548341c6L255-R255, previous versions of scrypt-js correctly rejected NaN input but 3.x doesn't.

Also, perhaps more checks are needed there, e.g. for the number to be non-negative (`>= 0`) and `<= Number.MAX_SAFE_INTEGER`. Wdyt?

Tests included.

Without the patch, the lib misbehaves on `NaN` and `Infinity` input.